### PR TITLE
Add support for AWS credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,12 @@ gem 'require_all'
 gem 'tty'
 gem 'http'
 gem 'nokogiri'
+
+group :test do
+  gem 'minitest'
+  gem 'rake'
+end
+
+group :development do
+  gem 'rubocop'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
+    ast (2.3.0)
     coderay (1.1.1)
     domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
@@ -17,19 +18,32 @@ GEM
     http_parser.rb (0.6.0)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
+    minitest (5.9.1)
     necromancer (0.3.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
+    parser (2.3.1.4)
+      ast (~> 2.2)
     pastel (0.6.1)
       equatable (~> 0.5.0)
       tty-color (~> 0.3.0)
     pkg-config (1.1.7)
+    powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rainbow (2.1.0)
+    rake (11.3.0)
     require_all (1.3.3)
+    rubocop (0.43.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     slop (3.6.0)
     tty (0.5.0)
       equatable (~> 0.5.0)
@@ -75,6 +89,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    unicode-display_width (1.1.1)
     unicode_utils (1.4.0)
     verse (0.4.0)
       unicode_utils (~> 1.4.0)
@@ -85,10 +100,13 @@ PLATFORMS
 
 DEPENDENCIES
   http
+  minitest
   nokogiri
   pry
+  rake
   require_all
+  rubocop
   tty
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.pattern = 'test/**/*_test.rb'
+end
+
+task default: :test

--- a/lib/plugin_list.rb
+++ b/lib/plugin_list.rb
@@ -1,6 +1,11 @@
 module Vcsmap
   class PluginList
     PLUGINS = {
+      aws: {
+        title: 'AWS access key',
+        description: 'Extracts AWS credentials from config and credentials files.',
+        class_name: 'Vcsmap::Plugin::AwsAccessToken'
+      },
       wordpress_config: {
         title: 'Wordpress configuration files',
         description: 'Extracts database credentials from wp-config.php.',

--- a/lib/plugins/aws_access_token.rb
+++ b/lib/plugins/aws_access_token.rb
@@ -1,0 +1,25 @@
+module Vcsmap
+  module Plugin
+    class AwsAccessToken < Vcsmap::Plugin::BasePlugin
+      def initialize
+        @search_string = ['aws_secret_access_key',
+                          'filename:config',
+                          'filename:credentials'].join('+')
+        @access_key_id_regex = /=\s+(AKIA[0-9A-Z]{16})/
+        @secret_access_key_regex = %r{=\s+([0-9a-zA-Z\/+]{40})}
+      end
+
+      def credentials(file)
+        @access_key_id = capture_match(@access_key_id_regex, file)
+        @secret_access_key = capture_match(@secret_access_key_regex, file)
+        [@access_key_id, @secret_access_key]
+      rescue NoMethodError
+        []
+      end
+
+      def table_header
+        ['Access Key ID', 'Secret Access Key']
+      end
+    end
+  end
+end

--- a/test/plugins/aws_access_token_test.rb
+++ b/test/plugins/aws_access_token_test.rb
@@ -1,0 +1,25 @@
+require_relative '../test_helper'
+
+require 'plugins/base_plugin'
+require 'plugins/aws_access_token'
+
+describe Vcsmap::Plugin::AwsAccessToken do
+  let(:plugin) { Vcsmap::Plugin::AwsAccessToken.new }
+
+  let(:file) do
+    <<-eos
+      [contoso]
+      aws_access_key_id = AKIAED8B369A90EDAB2A
+      aws_secret_access_key = EAB37ae33174B8A2B0f0/3798C78ca26EAB37AE3
+    eos
+  end
+
+  describe '#capture_match' do
+    it 'must return the matched AWS key pair' do
+      credentials = plugin.credentials(file)
+
+      expected = ['AKIAED8B369A90EDAB2A', 'EAB37ae33174B8A2B0f0/3798C78ca26EAB37AE3']
+      credentials.must_equal expected
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,3 @@
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+
+require 'minitest/autorun'


### PR DESCRIPTION
This adds support for extracting AWS credentials from `config` and `credentials` files, the two configuration files commonly used by AWS CLI and SDKs.

I took the liberty to add a very basic unit test (using minitest) for this plugin. Feel free to ignore it and only merge the plugin file.
